### PR TITLE
Refactor player widget and fix null safety issues

### DIFF
--- a/l10n/l10n_en.arb
+++ b/l10n/l10n_en.arb
@@ -9,5 +9,8 @@
     "retip": "Retip",
     "search": "Search",
     "storagePermission": "Storage access",
+    "unknownTitle": "Unknown Title",
+    "unknownAlbum": "Unknown Album",
+    "unknownArtist": "Unknown Artist",
     "@_END": {}
 }

--- a/l10n/untranslated.json
+++ b/l10n/untranslated.json
@@ -1,1 +1,7 @@
-{}
+{
+  "pl": [
+    "unknownTitle",
+    "unknownAlbum",
+    "unknownArtist"
+  ]
+}

--- a/lib/app/views/player/player_view.dart
+++ b/lib/app/views/player/player_view.dart
@@ -4,9 +4,9 @@ import 'package:get_it/get_it.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:retip/core/asset/retip_asset.dart';
 import 'package:retip/core/audio/retip_audio.dart';
+import 'package:retip/core/l10n/retip_l10n.dart';
 
 class PlayerView extends StatelessWidget {
-
   final RetipAudio player;
 
   const PlayerView({
@@ -90,19 +90,21 @@ class AudioInfoWidget extends StatelessWidget {
         stream: player.currentIndexStream,
         builder: (context, snapshot) {
           final index = snapshot.data ?? 0;
-          final track = (index >= 0 && index < player.tracks.length) ? player.tracks[index] : null;
+          final track = (index >= 0 && index < player.tracks.length)
+              ? player.tracks[index]
+              : null;
 
           return Column(
             children: [
               Text(
-                track?.title ?? 'Unknown Title',
+                track?.title ?? RetipL10n.of(context).unknownTitle,
                 style: Theme.of(context).textTheme.titleLarge,
               ),
               Text(
-                track?.artist ?? 'Unknown Artist',
+                track?.album ?? RetipL10n.of(context).unknownAlbum,
                 style: Theme.of(context).textTheme.titleMedium,
               ),
-              Text(track?.artist ?? 'Unknown Artist'),
+              Text(track?.artist ?? RetipL10n.of(context).unknownArtist),
               ProgressBar(player: player),
               const PlaybackButtons(),
             ],

--- a/lib/app/views/player/player_view.dart
+++ b/lib/app/views/player/player_view.dart
@@ -90,19 +90,19 @@ class AudioInfoWidget extends StatelessWidget {
         stream: player.currentIndexStream,
         builder: (context, snapshot) {
           final index = snapshot.data ?? 0;
-          final track = player.tracks[index];
+          final track = (index >= 0 && index < player.tracks.length) ? player.tracks[index] : null;
 
           return Column(
             children: [
               Text(
-                track.title,
+                track?.title ?? 'Unknown Title',
                 style: Theme.of(context).textTheme.titleLarge,
               ),
               Text(
-                track.album,
+                track?.artist ?? 'Unknown Artist',
                 style: Theme.of(context).textTheme.titleMedium,
               ),
-              Text(track.artist),
+              Text(track?.artist ?? 'Unknown Artist'),
               ProgressBar(player: player),
               const PlaybackButtons(),
             ],

--- a/lib/app/widgets/player/player_widget.dart
+++ b/lib/app/widgets/player/player_widget.dart
@@ -4,6 +4,7 @@ import 'package:get_it/get_it.dart';
 import 'package:retip/app/views/player/player_view.dart';
 import 'package:retip/core/asset/retip_asset.dart';
 import 'package:retip/core/audio/retip_audio.dart';
+import 'package:retip/core/l10n/retip_l10n.dart';
 
 class PlayerWidget extends StatelessWidget {
   const PlayerWidget({super.key});
@@ -73,9 +74,9 @@ class AudioInfoWidget extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                track?.title ?? 'Unknown Title',
+                track?.title ?? RetipL10n.of(context).unknownTitle,
               ),
-              Text(track?.artist ?? 'Unknown Artist'),
+              Text(track?.artist ?? RetipL10n.of(context).unknownArtist),
             ],
           );
         });

--- a/lib/app/widgets/player/player_widget.dart
+++ b/lib/app/widgets/player/player_widget.dart
@@ -36,13 +36,13 @@ class PlayerWidget extends StatelessWidget {
             Row(
               children: [
                 ArtworkWidget(player: player),
-                SizedBox(width: 16),
+                const SizedBox(width: 16),
                 AudioInfoWidget(player: player),
               ],
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8.0),
-              child: const PlayPauseIcon(
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8.0),
+              child: PlayPauseIcon(
                 size: 24,
               ),
             ),
@@ -67,15 +67,15 @@ class AudioInfoWidget extends StatelessWidget {
         stream: player.currentIndexStream,
         builder: (context, snapshot) {
           final index = snapshot.data ?? 0;
-          final track = player.tracks[index];
+          final track = (index >= 0 && index < player.tracks.length) ? player.tracks[index] : null;
 
           return Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                track.title,
+                track?.title ?? 'Unknown Title',
               ),
-              Text(track.artist),
+              Text(track?.artist ?? 'Unknown Artist'),
             ],
           );
         });
@@ -92,19 +92,19 @@ class ArtworkWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final size = 60.0;
+    const size = 60.0;
 
     return StreamBuilder<int?>(
       stream: player.currentIndexStream,
       builder: (context, snapshot) {
         final index = snapshot.data ?? 0;
-        final track = player.tracks[index];
+        final track = (index >= 0 && index < player.tracks.length) ? player.tracks[index] : null;
 
         return SizedBox.square(
           dimension: size,
-          child: track.artwork != null
+          child: track?.artwork != null
               ? Image.memory(
-                  track.artwork!,
+                  track!.artwork!,
                   width: size,
                   height: size,
                   fit: BoxFit.cover,


### PR DESCRIPTION
This Pull Request addresses a critical issue where the app throws an "index out of bounds" exception when no songs are downloaded to the local file system. The exception occurred while building the player widget due to an unhandled null value in the song list.

![issue_snapshot](https://github.com/user-attachments/assets/753c5252-eae7-4f2e-9e28-b2a4153190c1)

Changes:
I added a null safety check to handle cases where no songs are available locally, preventing the app from crashing due to the index out-of-bounds error.

These changes ensure the app behaves gracefully when no songs are found, improving the user experience and preventing potential crashes.